### PR TITLE
Fix: DateTimePicker rendering issues

### DIFF
--- a/src/components/countdown/MainCountdown.tsx
+++ b/src/components/countdown/MainCountdown.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 
 import { Time } from 'typings';
 import { CircularLoading } from 'components/common';
-import { getFutureTime } from 'utils/date';
+import { getRandomTimeInFuture } from 'utils/date';
 import styles from 'styles/components/countdown/MainCountdown.module.css';
 import CountdownTimer from './CountdownTimer';
 import TimeRangeForm from './TimeRangeForm';
@@ -13,12 +13,7 @@ const MainCountdown: FC = () => {
 
   useEffect(() => {
     setStartTime({ refersToNow: true });
-    setEndTime(
-      getFutureTime({
-        dayVariation: 48,
-        hoursVariation: 11,
-      }),
-    );
+    setEndTime(getRandomTimeInFuture());
   }, []);
 
   return (

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -68,32 +68,34 @@ export function getNumberOfDaysInMonth(month: number, year: number): number {
   return numberOfDaysInMonth[month];
 }
 
-interface FutureTimeOptions {
+interface RandomTimeInFutureOptions {
   dayVariation?: number;
   hoursVariation?: number;
+  minutesVariation?: number;
 }
 
-const futureTimeMinutes = 23;
-const futureTimeSeconds = 0;
+export function getRandomTimeInFuture(
+  options: RandomTimeInFutureOptions = {},
+): Time {
+  const placeholderDate = new Date();
 
-export function getFutureTime(options: FutureTimeOptions = {}): Time {
-  const now = new Date();
+  const currentDate = placeholderDate.getDate();
+  const currentHours = placeholderDate.getHours();
+  const currentMinutes = placeholderDate.getMinutes();
 
-  const currentDate = now.getDate();
-  const currentHours = now.getHours();
+  const { minutesVariation = currentMinutes * 3 } = options;
+  const { hoursVariation = currentHours + (minutesVariation % 24) } = options;
+  const { dayVariation = currentDate * 10 + hoursVariation } = options;
 
-  const { dayVariation = 0, hoursVariation = 0 } = options;
+  placeholderDate.setDate(currentDate + dayVariation);
+  placeholderDate.setHours(currentHours + hoursVariation);
+  placeholderDate.setMinutes(currentMinutes + minutesVariation);
+  placeholderDate.setSeconds(0);
 
-  const futureDate = new Date();
-  futureDate.setDate(currentDate + dayVariation);
-  futureDate.setHours(currentHours + hoursVariation);
-  futureDate.setMinutes(futureTimeMinutes);
-  futureDate.setSeconds(futureTimeSeconds);
-
-  const futureTime: Time = {
+  const timeInFuture: Time = {
     refersToNow: false,
-    date: futureDate,
+    date: placeholderDate,
   };
 
-  return futureTime;
+  return timeInFuture;
 }


### PR DESCRIPTION
## 🔧 Summary:
- Fixed _still_ occurring issues related to DateTimePicker component's rendering (for good, I hope). Now, the MainCountdown will only render the TimeRangeForm and the CountdownTimer when both startTime and endTime are non-nullish, displaying a loading sign meanwhile. As startTime and endTime are updated on mount, this will prevent the Server-side from rendering a DateTimePicker that might be different from Client-side's.